### PR TITLE
Add mime-support package (/etc/mime.types) to enable mime-wise raw preview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
         gitweb \
         highlight \
         libcgi-pm-perl \
+        mime-support \
         spawn-fcgi \
     && rm -rf /var/lib/apt/lists/* 
 


### PR DESCRIPTION
**Issue**
The gitweb doesn't take care of MIME so that raw contents will be always given to browser as text; i.e. there's no possibility to host static web page.

**Solution**
Adding the mime-support package makes the gitweb MIME-wise so that raw contents (e.g. `http://localhost:8080/?p=test.git;a=blob_plain;f=test.html;hb=HEAD`) will be treated expectedly by browser.
