### PR TITLE
修复 htpasswd 使用加密 在低linux内核版本 bug

### DIFF
--- a/src/cmd/addauth.sh
+++ b/src/cmd/addauth.sh
@@ -13,9 +13,11 @@ usage(){
 
 load(){
 	if [ ! -f $FPASS ]; then
-  		htpasswd -bc $FPASS $1 $2
-	else
-      htpasswd -b $FPASS $1 $2 
+  		touch $FPASS
+	fi	
+	htpasswd -b $FPASS $1 $2 
+	if [ "$?" != 0 ] ; then
+  		htpasswd -bp $FPASS $1 $2
 	fi
 }
 


### PR DESCRIPTION
fixed #4 

使用加密

```
root@50b303640d95:/# htpasswd -nb uu pp

> htpasswd: Unable to generate random bytes: Function not implemented
```
尝试不使用加密
use -p 
>  -p  Do not encrypt the password (plaintext, insecure).
```
root@50b303640d95:/# htpasswd -npb uu pp
> Warning: storing passwords as plain text might just not work on this platform.
uu:pp

```
测试正常