### PR TITLE
修复 htpasswd 使用加密 在 linux 低内核版本报错的 bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN cp /usr/share/gitweb/static/gitweb.css /usr/share/gitweb/static/gitweb.css.o
 RUN mkdir /usr/share/gitweb/ihm
 
 VOLUME /var/lib/git
+WORKDIR /var/lib/git
 EXPOSE 80
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/cmd/addauth.sh
+++ b/src/cmd/addauth.sh
@@ -13,9 +13,11 @@ usage(){
 
 load(){
 	if [ ! -f $FPASS ]; then
-  		htpasswd -bc $FPASS $1 $2
-	else
-      htpasswd -b $FPASS $1 $2 
+  		touch $FPASS
+	fi	
+	htpasswd -b $FPASS $1 $2 
+	if [ "$?" != 0 ] ; then
+  		htpasswd -bp $FPASS $1 $2
 	fi
 }
 

--- a/src/cmd/addauth.sh
+++ b/src/cmd/addauth.sh
@@ -17,7 +17,8 @@ load(){
 	fi	
 	htpasswd -b $FPASS $1 $2 
 	if [ "$?" != 0 ] ; then
-  		htpasswd -bp $FPASS $1 $2
+  		htpasswd -D $FPASS $1
+  		printf "$1:$(openssl passwd -apr1 $2)\n" >> $FPASS
 	fi
 }
 

--- a/src/cmd/addrepos.sh
+++ b/src/cmd/addrepos.sh
@@ -17,6 +17,7 @@ load(){
   		mkdir $REPOS
 		cd $REPOS
 		git init --bare
+		echo "$1" > description
 		chmod -R 777 $REPOS
 	fi
 }


### PR DESCRIPTION
fixed #4 

使用 `htpasswd` 加密密码: 
```
root@50b303640d95:/# htpasswd -nb uu pp

> htpasswd: Unable to generate random bytes: Function not implemented
```

使用 `htpasswd` 明文密码: 

- `-p Do not encrypt the password (plaintext, insecure).`
```
root@50b303640d95:/# docker-compose logs -f gitweb
gitweb | 2022/06/09 04:57:31 [error] 37#37: *6 user "uu": password mismatch,
```
使用 `openssl passwd` 加密密码: 
```
root@50b303640d95:/# printf "uu:$(openssl passwd -apr1 pp)\n"
> uu:$apr1$pYsO9KFh$ZOeuVdAzbkxPd.5WZ1aCv/
```

测试正常