### PR TITLE
docker-publish use Github Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,117 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: ["master", "develop"]
+    # Publish semver tags as releases.
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: ["master", "develop"]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  # REGISTRY: ghcr.io
+  REGISTRY: docker.io
+  # github.repository as <account>/<repo>
+  APP_NAME: gitweb
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: "v1.13.1"
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        if: github.event_name != 'pull_request'
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ secrets.REGISTRY_USERNAME }}/${{ env.APP_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=pep440,pattern={{version}}
+            
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and load Docker image
+        id: build-and-load
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          load: true
+          tags: ${{ secrets.REGISTRY_USERNAME }}/${{ env.APP_NAME }}:test
+          no-cache: true
+
+      - name: Test Docker image
+        run: |
+          docker run -d  -e "GITPROJECT=test" -v $(pwd)/test:/test --name test ${{ secrets.REGISTRY_USERNAME }}/${{ env.APP_NAME }}:test 
+          sleep 15
+          docker exec -i ${{ secrets.REGISTRY_USERNAME }}/${{ env.APP_NAME }}:test chmod +x /test/load.sh
+          docker exec -i ${{ secrets.REGISTRY_USERNAME }}/${{ env.APP_NAME }}:test /test/load.sh
+
+      - name: Build and push Docker image
+        if: github.event_name != 'pull_request'
+        id: build-and-push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/386,linux/arm/v7,linux/amd64,linux/arm64/v8
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ secrets.REGISTRY_USERNAME }}/${{ env.APP_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ secrets.REGISTRY_USERNAME }}/${{ env.APP_NAME }}:buildcache,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,10 +85,10 @@ jobs:
 
       - name: Test Docker image
         run: |
-          docker run -d  -e "GITPROJECT=test" -v $(pwd)/test:/test --name test ${{ secrets.REGISTRY_USERNAME }}/${{ env.APP_NAME }}:test 
+          docker run -d  -e "GITPROJECT=test" -v $(pwd)/test:/test --name gitweb-test ${{ secrets.REGISTRY_USERNAME }}/${{ env.APP_NAME }}:test 
           sleep 15
-          docker exec -i ${{ secrets.REGISTRY_USERNAME }}/${{ env.APP_NAME }}:test chmod +x /test/load.sh
-          docker exec -i ${{ secrets.REGISTRY_USERNAME }}/${{ env.APP_NAME }}:test /test/load.sh
+          docker exec -i gitweb-test chmod +x /test/load.sh
+          docker exec -i gitweb-test /test/load.sh
 
       - name: Build and push Docker image
         if: github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15
+FROM nginx:1.19
 LABEL maintainer "fraoustin@gmail.com"
 
 COPY ./src/default.conf /etc/nginx/conf.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
         gitweb \
         highlight \
         libcgi-pm-perl \
+        mime-support \
         spawn-fcgi \
     && rm -rf /var/lib/apt/lists/* 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN cp /usr/share/gitweb/static/gitweb.css /usr/share/gitweb/static/gitweb.css.o
 RUN mkdir /usr/share/gitweb/ihm
 
 VOLUME /var/lib/git
+WORKDIR /var/lib/git
 EXPOSE 80
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21
+FROM nginx:1.23
 LABEL maintainer "fraoustin@gmail.com"
 
 COPY ./src/default.conf /etc/nginx/conf.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.19
+FROM nginx:1.21
 LABEL maintainer "fraoustin@gmail.com"
 
 COPY ./src/default.conf /etc/nginx/conf.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.13
+FROM nginx:1.15
 LABEL maintainer "fraoustin@gmail.com"
 
 COPY ./src/default.conf /etc/nginx/conf.d/default.conf

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: "3"
+
+volumes:
+    gitweb:
+
+
+services:
+    gitweb:
+        image: fraoustin/gitweb
+        container_name: gitweb
+        hostname: gitweb
+        environment:
+            - SET_CONTAINER_TIMEZONE=true
+            - CONTAINER_TIMEZONE=Europe/Paris
+            - GITPROJECT=test
+            - GITUSER=gituser
+            - GITPASSWORD=gitpassword
+            - IHM=""
+        ports:
+            - 8080:80
+        restart: always
+        volumes:
+            - gitweb:/var/lib/git/

--- a/src/cmd/addauth.sh
+++ b/src/cmd/addauth.sh
@@ -13,9 +13,11 @@ usage(){
 
 load(){
 	if [ ! -f $FPASS ]; then
-  		htpasswd -bc $FPASS $1 $2
-	else
-      htpasswd -b $FPASS $1 $2 
+  		touch $FPASS
+	fi	
+	htpasswd -b $FPASS $1 $2 
+	if [ "$?" != 0 ] ; then
+  		htpasswd -bp $FPASS $1 $2
 	fi
 }
 

--- a/src/cmd/addauth.sh
+++ b/src/cmd/addauth.sh
@@ -17,7 +17,8 @@ load(){
 	fi	
 	htpasswd -b $FPASS $1 $2 
 	if [ "$?" != 0 ] ; then
-  		htpasswd -bp $FPASS $1 $2
+  		htpasswd -D $FPASS $1
+  		printf "$1:$(openssl passwd -apr1 $2)\n" >> $FPASS
 	fi
 }
 

--- a/src/cmd/addrepos.sh
+++ b/src/cmd/addrepos.sh
@@ -17,6 +17,7 @@ load(){
   		mkdir $REPOS
 		cd $REPOS
 		git init --bare
+		echo "$1" > description
 		chmod -R 777 $REPOS
 	fi
 }

--- a/test/load.sh
+++ b/test/load.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+git config --global user.email "you@example.com"
+git config --global user.name "Your Name"
 cd /tmp
 git clone http://gituser:gitpassword@localhost:80/test.git
 cd test

--- a/test/load.sh
+++ b/test/load.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd /tmp
-git clone http://gituser:gitpassword@localhost:8080/test.git
+git clone http://gituser:gitpassword@localhost:80/test.git
 cd test
 git branch master
 git checkout master


### PR DESCRIPTION
Build platforms: linux/386,linux/arm/v7,linux/amd64,linux/arm64/v8

Result temp page:
<https://hub.docker.com/repository/docker/zctmdc/gitweb/tags>

Please open github repositorie
Follow：
-  `Settings` 
-  `secrets` 
-  `Actions` 

Now you can see **Actions secrets**

Click:  `New repository secret`

Add: `REGISTRY_USERNAME` and `REGISTRY_TOKEN`

It's can be found at:

<https://docs.docker.com/docker-hub/access-tokens/>

<https://github.com/docker/login-action#docker-hub>
Yep, I set the key-value is `REGISTRY_USERNAME` and `REGISTRY_TOKEN`